### PR TITLE
Add autocompletion

### DIFF
--- a/autocompletion/tldr.bash
+++ b/autocompletion/tldr.bash
@@ -1,9 +1,17 @@
-function _tldr_autocomplete {
-    commands=$(tldr list)
-    COMPREPLY=()
+_tldr_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _TLDR_COMPLETE=complete $1 ) )
+
     if [ $COMP_CWORD = 2 ]; then
-        COMPREPLY=(`compgen -W "$commands" -- $2`)
+        command_name=${COMP_WORDS[COMP_CWORD-1]}
+        if [[ "$command_name" == "find" ]] || [[ "$command_name" == "locate" ]]; then
+            pages=$(tldr list)
+            COMPREPLY=(`compgen -W "$pages" -- $2`)
+        fi
     fi
+
+    return 0
 }
 
-complete -F _tldr_autocomplete tldr
+complete -F _tldr_completion -o default tldr;

--- a/autocompletion/tldr.bash
+++ b/autocompletion/tldr.bash
@@ -1,0 +1,9 @@
+function _tldr_autocomplete {
+    commands=$(tldr list)
+    COMPREPLY=()
+    if [ $COMP_CWORD = 2 ]; then
+        COMPREPLY=(`compgen -W "$commands" -- $2`)
+    fi
+}
+
+complete -F _tldr_autocomplete tldr

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 click
 PyYaml
-pytest >= 2.8
+pytest >= 3.2
 pytest-flake8
 pytest-cov
 mock >= 1.3.0

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -53,3 +53,9 @@ class BasicTestCase(unittest.TestCase):
             [command_name, '--on', platform] if platform else [command_name])
         result = self.runner.invoke(cli.locate, command_args)
         return result
+
+    def call_list_command(self, command_name, platform):
+        command_args = (
+            [command_name, '--on', platform] if platform else [command_name])
+        result = self.runner.invoke(cli.list, command_args)
+        return result

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from os import path
+import shutil
+
+from basic import BasicTestCase
+
+
+class Testlist(BasicTestCase):
+    def setUp(self):
+        super(Testlist, self).setUp()
+
+        # Add a new page.
+        self.page_path = path.join(self.repo_dir, 'pages')
+
+        # Backup the index.json.
+        shutil.copy(path.join(self.page_path, 'index.json'),
+                    path.join(self.page_path, 'index_bak.json'))
+        self.call_reindex_command()
+
+    def tearDown(self):
+        super(Testlist, self).tearDown()
+        # Restore the index.json.
+        if path.exists(path.join(self.page_path, 'index_bak.json')):
+            shutil.move(path.join(self.page_path, 'index_bak.json'),
+                        path.join(self.page_path, 'index.json'))
+
+    def test_common_command(self):
+        self._assert_command_output(
+            '',
+            'airport du tcpflow tldr\n'
+        )
+
+    def _assert_command_output(self, command_name, expected_output,
+                               platform=''):
+        result = self.call_list_command(command_name, platform)
+        assert result.output == expected_output

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -26,17 +26,29 @@ def parse_man_page(command, platform):
     return output_lines
 
 
+def get_index():
+    """Retrieve index in the pages directory."""
+    repo_directory = get_config()['repo_directory']
+    with io.open(path.join(repo_directory, 'pages/index.json'),
+                 encoding='utf-8') as f:
+        index = json.load(f)
+    return index
+
+
+def find_commands():
+    """List commands in the pages directory."""
+    index = get_index()
+    return [item['name'] for item in index['commands']]
+
+
 def find_page_location(command, specified_platform):
     """Find the command man page in the pages directory."""
     repo_directory = get_config()['repo_directory']
     default_platform = get_config()['platform']
     command_platform = (
         specified_platform if specified_platform else default_platform)
-
-    with io.open(path.join(repo_directory, 'pages/index.json'),
-                 encoding='utf-8') as f:
-        index = json.load(f)
-    command_list = [item['name'] for item in index['commands']]
+    index = get_index()
+    command_list = find_commands()
     if command not in command_list:
         sys.exit(
             ("Sorry, we don't support command: {0} right now.\n"
@@ -176,3 +188,13 @@ def locate(command, on):
     """Locate the command's man page."""
     location = find_page_location(command, on)
     click.echo(location)
+
+
+@cli.command()
+@click.argument('command', required=False)
+@click.option('--on', type=click.Choice(['linux', 'osx', 'sunos']),
+              help='the specified platform.')
+def list(command, on):
+    """list the command's man page."""
+    command_list = find_commands()
+    click.echo(' '.join(command_list))


### PR DESCRIPTION
Hi 
As I'm coming from cheat, I borrowed them this : https://github.com/chrisallenlane/cheat/wiki/Enabling-Command-line-Autocompletion

I don't know if the added test is well done, but they're all passing with python 3.6.

After copying autocompletion/tldr.bash to /etc/bash_completion.d/ (on ubuntu), autocompletion will be available like this : 
```bash
~/tldr.py$ tldr find ta[tab]
tabula  tac     tail    tar     task
```