### PR TITLE
Replace SSH url repo with HTTPS url repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Initialize
    ::
 
        $ cd ~/code
-       $ git clone git@github.com:tldr-pages/tldr.git
+       $ git clone https://github.com/lord63/tldr.py.git
 
 -  then, init the configuration file, the default location for the
    configuration file is your home directory, you can use the


### PR DESCRIPTION
I believe most users don't have their SSH public keys imported in this repository, so they can only do `git clone` via HTTPS and not SSH. ;)