### PR TITLE
Added support for XDG_COFIG_HOME

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Initialize
        $ tldr init
        Input the tldr repo path(absolute path): (e.g. /home/lord63/code/tldr/)
        Input your platform(linux, osx or sunos): (e.g. linux)
-       Initializing the config file at ~/.tldrrc
+       Initializing the config file at ~/.config/tldr.py.conf
 
 and you configuration file should look like this:
 
@@ -139,7 +139,7 @@ rebuild the index; done.
 
     Q: I don't like the default color theme, how to change it?
 
-A: Edit the tldr configuration file at ``~/.tldrrc``; modify the color
+A: Edit the tldr configuration file at ``~/.config/tldr.py.conf``; modify the color
 until you're happy with it.
 
     Q: I faided to update the tldr pages, why?

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -18,7 +18,7 @@ ROOT = path.dirname(path.realpath(__file__))
 class BasicTestCase(unittest.TestCase):
     def setUp(self):
         self.repo_dir = path.join(ROOT, 'mock_tldr')
-        self.config_path = path.join(self.repo_dir, '.tldrrc')
+        self.config_path = path.join(self.repo_dir, 'tldr.py.conf')
         os.environ['TLDR_CONFIG_DIR'] = self.repo_dir
         self.runner = CliRunner()
         self.call_init_command()

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -129,8 +129,10 @@ def update():
 def init():
     """Init config file."""
     default_config_path = path.join(
-        (os.environ.get('TLDR_CONFIG_DIR') or path.expanduser('~')),
-        '.tldrrc')
+        (os.environ.get('TLDR_CONFIG_DIR') or
+         os.environ.get('XDG_CONFIG_DIR') or
+         path.join(path.expanduser('~'), '.config')),
+        'tldr.py.conf')
     if path.exists(default_config_path):
         click.echo("There is already a config file exists, "
                    "skip initializing it.")

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -130,7 +130,7 @@ def init():
     """Init config file."""
     default_config_path = path.join(
         (os.environ.get('TLDR_CONFIG_DIR') or
-         os.environ.get('XDG_CONFIG_DIR') or
+         os.environ.get('XDG_CONFIG_HOME') or
          path.join(path.expanduser('~'), '.config')),
         'tldr.py.conf')
     if path.exists(default_config_path):

--- a/tldr/config.py
+++ b/tldr/config.py
@@ -15,7 +15,7 @@ def get_config():
     """Get the configurations from config file and return it as a dict."""
     config_path = path.join(
         (os.environ.get('TLDR_CONFIG_DIR') or
-         os.environ.get('XDG_CONFIG_DIR') or
+         os.environ.get('XDG_CONFIG_HOME') or
          path.join(path.expanduser('~'), '.config')),
         'tldr.py.conf')
     if not path.exists(config_path):

--- a/tldr/config.py
+++ b/tldr/config.py
@@ -12,10 +12,12 @@ import yaml
 
 
 def get_config():
-    """Get the configurations from .tldrrc and return it as a dict."""
+    """Get the configurations from config file and return it as a dict."""
     config_path = path.join(
-        (os.environ.get('TLDR_CONFIG_DIR') or path.expanduser('~')),
-        '.tldrrc')
+        (os.environ.get('TLDR_CONFIG_DIR') or
+         os.environ.get('XDG_CONFIG_DIR') or
+         path.join(path.expanduser('~'), '.config')),
+        'tldr.py.conf')
     if not path.exists(config_path):
         sys.exit("Can't find config file at: {0}. You may use `tldr init` "
                  "to init the config file.".format(config_path))


### PR DESCRIPTION
If XDG_COFIG_HOME is set on the machine then make the config inside it.
Otherwise the config file is made in ~/.config/.
Default config file name has changed to tldr.py.conf