### PR TITLE
Migrate branch from master to main

### DIFF
--- a/tests/basic.py
+++ b/tests/basic.py
@@ -35,7 +35,8 @@ class BasicTestCase(unittest.TestCase):
 
     def call_update_command(self):
         with mock.patch('tldr.cli.build_index', return_value=None):
-            result = self.runner.invoke(cli.update)
+            with mock.patch('subprocess.call', return_value=0):
+                result = self.runner.invoke(cli.update)
         return result
 
     def call_find_command(self, command_name, platform):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -6,9 +6,16 @@ from __future__ import absolute_import
 import mock
 
 from basic import BasicTestCase
+from tldr import cli
 
 
 class TestUpdate(BasicTestCase):
+    def test_no_main_branch(self):
+        with mock.patch('subprocess.call', return_value=1):
+            result = self.runner.invoke(cli.update)
+        assert result.exit_code != 0
+        assert "renamed 'master' to 'main'" in result.output
+
     def test_update_available(self):
         mock_different_sha1 = [
             '8f82e7445fef6cc83c2e02b82df5f92fe0a909c6',

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -136,13 +136,13 @@ def update():
     os.chdir(repo_directory)
     click.echo("Check for updates...")
 
-    local = subprocess.check_output('git rev-parse master'.split()).strip()
+    local = subprocess.check_output('git rev-parse main'.split()).strip()
     remote = subprocess.check_output(
         'git ls-remote https://github.com/tldr-pages/tldr/ HEAD'.split()
     ).split()[0]
     if local != remote:
         click.echo("Updating...")
-        subprocess.check_call('git checkout master'.split())
+        subprocess.check_call('git checkout main'.split())
         subprocess.check_call('git pull --rebase'.split())
         build_index()
         click.echo("Update to the latest and rebuild the index.")

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -134,6 +134,18 @@ def update():
     """Update to the latest pages."""
     repo_directory = get_config()['repo_directory']
     os.chdir(repo_directory)
+
+    if subprocess.call(
+        ['git', 'rev-parse', '--verify', 'main'],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    ) != 0:
+        sys.exit(
+            "The tldr-pages repo has renamed 'master' to 'main'.\n"
+            "Please run the following commands to migrate:\n"
+            "    cd {0} && git fetch origin && git checkout main\n"
+            "Then try again.".format(repo_directory)
+        )
+
     click.echo("Check for updates...")
 
     local = subprocess.check_output('git rev-parse main'.split()).strip()

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -142,7 +142,7 @@ def update():
         sys.exit(
             "The tldr-pages repo has renamed 'master' to 'main'.\n"
             "Please run the following commands to migrate:\n"
-            "    cd {0} && git fetch origin && git checkout main\n"
+            "    cd {0} && git fetch origin && git checkout -b main origin/main && cd -\n"
             "Then try again.".format(repo_directory)
         )
 


### PR DESCRIPTION
the upstream source has change the branch from master to main, there is no master branch now, which break the update logic.

New solution is check whether exist user is using the old master branch and tell user to do the migration, new user won't affect.